### PR TITLE
Bugfixes + optional features

### DIFF
--- a/binding/tilemap-binding.cpp
+++ b/binding/tilemap-binding.cpp
@@ -85,11 +85,16 @@ RB_METHOD(tilemapInitialize) {
   /* Construct object */
   t = new Tilemap(viewport);
 
-  setPrivateData(self, t);
-
   rb_iv_set(self, "viewport", viewportObj);
 
+  setPrivateData(self, t);
+
+  t->initDynAttribs();
+
   wrapProperty(self, &t->getAutotiles(), "autotiles", TilemapAutotilesType);
+
+  wrapProperty(self, &t->getColor(), "color", ColorType);
+  wrapProperty(self, &t->getTone(), "tone", ToneType);
 
   VALUE autotilesObj = rb_iv_get(self, "autotiles");
 
@@ -137,10 +142,16 @@ DEF_PROP_OBJ_REF(Tilemap, Table, MapData, "map_data")
 DEF_PROP_OBJ_REF(Tilemap, Table, FlashData, "flash_data")
 DEF_PROP_OBJ_REF(Tilemap, Table, Priorities, "priorities")
 
+DEF_PROP_OBJ_VAL(Tilemap, Color, Color, "color")
+DEF_PROP_OBJ_VAL(Tilemap, Tone, Tone, "tone")
+
 DEF_PROP_B(Tilemap, Visible)
 
 DEF_PROP_I(Tilemap, OX)
 DEF_PROP_I(Tilemap, OY)
+
+DEF_PROP_I(Tilemap, Opacity)
+DEF_PROP_I(Tilemap, BlendType)
 
 void tilemapBindingInit() {
   VALUE klass = rb_define_class("TilemapAutotiles", rb_cObject);
@@ -173,4 +184,9 @@ void tilemapBindingInit() {
   INIT_PROP_BIND(Tilemap, Visible, "visible");
   INIT_PROP_BIND(Tilemap, OX, "ox");
   INIT_PROP_BIND(Tilemap, OY, "oy");
+
+  INIT_PROP_BIND(Tilemap, Opacity, "opacity");
+  INIT_PROP_BIND(Tilemap, BlendType, "blend_type");
+  INIT_PROP_BIND(Tilemap, Color, "color");
+  INIT_PROP_BIND(Tilemap, Tone, "tone");
 }

--- a/shader/meson.build
+++ b/shader/meson.build
@@ -13,6 +13,7 @@ embedded_shaders = [
     'simpleColor.frag',
     'simpleAlpha.frag',
     'simpleAlphaUni.frag',
+    'tilemap.frag',
     'flashMap.frag',
     'minimal.vert',
     'simple.vert',

--- a/shader/tilemap.frag
+++ b/shader/tilemap.frag
@@ -1,0 +1,33 @@
+
+uniform sampler2D v_texture;
+
+uniform lowp vec4 tone;
+
+uniform lowp float opacity;
+uniform lowp vec4 color;
+
+in vec2 v_texCoord;
+
+const vec3 lumaF = vec3(.299, .587, .114);
+
+out vec4 fragColor;
+
+void main() {
+  /* Sample source color */
+  vec4 frag = texture(v_texture, v_texCoord);
+
+  /* Apply gray */
+  float luma = dot(frag.rgb, lumaF);
+  frag.rgb = mix(frag.rgb, vec3(luma), tone.w);
+
+  /* Apply tone */
+  frag.rgb += tone.rgb;
+
+  /* Apply opacity */
+  frag.a *= opacity;
+
+  /* Apply color */
+  frag.rgb = mix(frag.rgb, color.rgb, color.a);
+
+  fragColor = frag;
+}

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -41,6 +41,7 @@
 #include "simpleColor.frag.xxd"
 #include "simpleAlpha.frag.xxd"
 #include "simpleAlphaUni.frag.xxd"
+#include "tilemap.frag.xxd"
 #include "flashMap.frag.xxd"
 #include "minimal.vert.xxd"
 #include "simple.vert.xxd"
@@ -515,11 +516,30 @@ void GrayShader::setGray(float value)
 
 TilemapShader::TilemapShader()
 {
-	INIT_SHADER(tilemap, simple, TilemapShader);
+	INIT_SHADER(tilemap, tilemap, TilemapShader);
 
 	ShaderBase::init();
 
+	GET_U(tone);
+	GET_U(color);
+	GET_U(opacity);
+
 	GET_U(aniIndex);
+}
+
+void TilemapShader::setTone(const Vec4 &tone)
+{
+	setVec4Uniform(u_tone, tone);
+}
+
+void TilemapShader::setColor(const Vec4 &color)
+{
+	setVec4Uniform(u_color, color);
+}
+
+void TilemapShader::setOpacity(float value)
+{
+	gl.Uniform1f(u_opacity, value);
 }
 
 void TilemapShader::setAniIndex(int value)

--- a/src/shader.h
+++ b/src/shader.h
@@ -220,8 +220,12 @@ public:
 
 	void setAniIndex(int value);
 
+	void setTone(const Vec4 &value);
+	void setColor(const Vec4 &value);
+	void setOpacity(float value);
+
 private:
-	GLint u_aniIndex;
+	GLint u_aniIndex, u_tone, u_color, u_opacity;
 };
 
 class FlashMapShader : public ShaderBase

--- a/src/tilemap.cpp
+++ b/src/tilemap.cpp
@@ -659,8 +659,8 @@ struct TilemapPrivate
 			Quad::setTexPosRect(v, texRect, posRect);
 
 			/* Iterate over 4 vertices */
-			for (size_t i = 0; i < 4; ++i)
-				array->push_back(v[i]);
+			for (size_t j = 0; j < 4; ++j)
+				array->push_back(v[j]);
 		}
 	}
 
@@ -689,6 +689,8 @@ struct TilemapPrivate
 		else
 		{
 			int layerInd = y + prio;
+			if (layerInd >= zlayersMax)
+				return;
 			targetArray = &zlayerVert[layerInd];
 		}
 

--- a/src/tilemap.cpp
+++ b/src/tilemap.cpp
@@ -726,8 +726,30 @@ struct TilemapPrivate
 	{
 		clearQuadArrays();
 
-		for (int x = 0; x < viewpW; ++x)
-			for (int y = 0; y < viewpH; ++y)
+		int ox = viewpPos.x;
+		int oy = viewpPos.y;
+		int mapW = mapData->xSize();
+		int mapH = mapData->ySize();
+
+		int minX = 0;
+		int minY = 0;
+		if (ox < 0)
+			minX = -ox;
+		if (oy < 0)
+			minY = -oy;
+
+		// There could be off-by-one issues in these couple sections.
+		int maxX = viewpW;
+		int maxY = viewpH;
+		if (ox + maxX >= mapW)
+			maxX = mapW - ox - 1;
+		if (oy + maxY >= mapH)
+			maxY = mapH - oy - 1;
+
+		if ((minX > maxX) || (minY > maxY))
+			return;
+		for (int x = minX; x <= maxX; ++x)
+			for (int y = minY; y <= maxY; ++y)
 				for (int z = 0; z < mapData->zSize(); ++z)
 					handleTile(x, y, z);
 	}

--- a/src/tilemap.h
+++ b/src/tilemap.h
@@ -30,6 +30,9 @@ class Viewport;
 class Bitmap;
 class Table;
 
+struct Color;
+struct Tone;
+
 struct TilemapPrivate;
 
 class Tilemap : public Disposable
@@ -65,6 +68,13 @@ public:
 	DECL_ATTR( Visible,    bool      )
 	DECL_ATTR( OX,         int       )
 	DECL_ATTR( OY,         int       )
+
+	DECL_ATTR( Opacity,   int     )
+	DECL_ATTR( BlendType, int     )
+	DECL_ATTR( Color,     Color&  )
+	DECL_ATTR( Tone,      Tone&   )
+
+	void initDynAttribs();
 
 private:
 	TilemapPrivate *p;


### PR DESCRIPTION
Hello, had this as a pet project for a few days.

- d45eaf6 and d261d6b are isolated bugfixes for the Tilemap class.
- 7d72c01 adds features, but is backwards-compatible; optional.
- cda7497 mostly likely breaks compatibility, since it assumes that 3x4 autotiles have 8 frames instead of 4; you might not want to merge this.

Together they suffice to replace Essentials' CustomTilemap.

(I don't actually use C++ or Ruby, so my code's probably awful.)